### PR TITLE
Support the LuaExtended Package

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -6,5 +6,5 @@ class Lua(Linter):
     regex = r'^.+?:.+?:(?P<line>\d+): (?P<message>.+?(?:near (?P<near>\'.+\')|$))'
     error_stream = util.STREAM_STDERR
     defaults = {
-        'selector': 'source.lua'
+        'selector': 'source.lua, source.luae'
     }


### PR DESCRIPTION
Hello,

I am the maintainer of [LuaExtended](https://packagecontrol.io/packages/LuaExtended), an alternative Lua syntax definition for ST3. With the not-so-recent deprecation of `syntax_map`, it is now harder for my users to configure linting properly. Would you please support my package out of the box, like [SublimeLinter-luacheck](https://packagecontrol.io/packages/SublimeLinter-luacheck) does?